### PR TITLE
PEG-2095: Upgrade jackson to 2.15.0 to fix security vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 [Semantic Versioning](http://semver.org/).
 
 ### [Unreleased]
+### Security
+- Upgrade jackson to version 2.15.0 to fix security vulnerabilities:
+  - **CVE-2022-42003** Detail: https://cwe.mitre.org/data/definitions/502.html
+  - **CVE-2025-52999** Detail: https://cwe.mitre.org/data/definitions/121.html
+  - **CVE-2022-42004** Detail: https://cwe.mitre.org/data/definitions/400.html
+  - **CCVE-2025-49128** Detail: https://cwe.mitre.org/data/definitions/209.html
+
 
 # [17.103.0] - 2025-07-16
 ### Added

--- a/aggregate-snapshot/aggregate-snapshot-service/src/test/java/uk/gov/justice/services/eventsourcing/source/core/SnapshotAwareEventSourceProducerTest.java
+++ b/aggregate-snapshot/aggregate-snapshot-service/src/test/java/uk/gov/justice/services/eventsourcing/source/core/SnapshotAwareEventSourceProducerTest.java
@@ -42,7 +42,7 @@ public class SnapshotAwareEventSourceProducerTest {
         final EventSourceDefinition eventSourceDefinition = eventSourceDefinition()
                 .withName("defaultEventSource")
                 .withDefault(true)
-                .withLocation(new Location("", empty(), of(jndiDataSourceName)))
+                .withLocation(new Location("", null, jndiDataSourceName))
                 .build();
         final EventSourceName eventSourceNameAnnotation = mock(EventSourceName.class);
         final JdbcBasedEventSource jdbcBasedEventSource = mock(JdbcBasedEventSource.class);
@@ -60,7 +60,7 @@ public class SnapshotAwareEventSourceProducerTest {
         final EventSourceDefinition eventSourceDefinition = eventSourceDefinition()
                 .withName("defaultEventSource")
                 .withDefault(true)
-                .withLocation(new Location("", empty(), of(jndiDataSourceName)))
+                .withLocation(new Location("", null, jndiDataSourceName))
                 .build();
         final JdbcBasedEventSource jdbcBasedEventSource = mock(JdbcBasedEventSource.class);
 
@@ -76,7 +76,7 @@ public class SnapshotAwareEventSourceProducerTest {
         final EventSourceDefinition eventSourceDefinition = eventSourceDefinition()
                 .withName("defaultEventSource")
                 .withDefault(true)
-                .withLocation(new Location("", empty(), empty()))
+                .withLocation(new Location("", null, null))
                 .build();
         final EventSourceName eventSourceNameAnnotation = mock(EventSourceName.class);
         final JdbcBasedEventSource jdbcBasedEventSource = mock(JdbcBasedEventSource.class);

--- a/event-sourcing/event-source/src/test/java/uk/gov/justice/services/eventsourcing/source/core/EventSourceProducerTest.java
+++ b/event-sourcing/event-source/src/test/java/uk/gov/justice/services/eventsourcing/source/core/EventSourceProducerTest.java
@@ -42,7 +42,7 @@ public class EventSourceProducerTest {
         final EventSourceDefinition eventSourceDefinition = eventSourceDefinition()
                 .withName("defaultEventSource")
                 .withDefault(true)
-                .withLocation(new Location("", empty(), of(jndiDataSourceName)))
+                .withLocation(new Location("", null, jndiDataSourceName))
                 .build();
         final EventSourceName eventSourceName = mock(EventSourceName.class);
         final JdbcBasedEventSource jdbcBasedEventSource = mock(JdbcBasedEventSource.class);
@@ -60,7 +60,7 @@ public class EventSourceProducerTest {
         final EventSourceDefinition eventSourceDefinition = eventSourceDefinition()
                 .withName("defaultEventSource")
                 .withDefault(true)
-                .withLocation(new Location("", empty(), of(jndiDataSourceName)))
+                .withLocation(new Location("", null, jndiDataSourceName))
                 .build();
 
         final JdbcBasedEventSource jdbcBasedEventSource = mock(JdbcBasedEventSource.class);
@@ -77,7 +77,7 @@ public class EventSourceProducerTest {
         final EventSourceDefinition eventSourceDefinition = eventSourceDefinition()
                 .withName("defaultEventSource")
                 .withDefault(true)
-                .withLocation(new Location("", empty(), empty()))
+                .withLocation(new Location("", null, null))
                 .build();
         final EventSourceName eventSourceName = mock(EventSourceName.class);
         final JdbcBasedEventSource jdbcBasedEventSource = mock(JdbcBasedEventSource.class);

--- a/event-sourcing/event-source/src/test/java/uk/gov/justice/services/eventsourcing/source/core/PublishedEventSourceProducerTest.java
+++ b/event-sourcing/event-source/src/test/java/uk/gov/justice/services/eventsourcing/source/core/PublishedEventSourceProducerTest.java
@@ -49,7 +49,7 @@ public class PublishedEventSourceProducerTest {
         final EventSourceDefinition eventSourceDefinition = eventSourceDefinition()
                 .withName("defaultEventSource")
                 .withDefault(true)
-                .withLocation(new Location("", empty(), Optional.of("dataSource")))
+                .withLocation(new Location("", null, "dataSource"))
                 .build();
         final InjectionPoint injectionPoint = mock(InjectionPoint.class);
         final EventSourceName eventSourceNameAnnotation = mock(EventSourceName.class);
@@ -67,7 +67,7 @@ public class PublishedEventSourceProducerTest {
         final EventSourceDefinition eventSourceDefinition = eventSourceDefinition()
                 .withName("defaultEventSource")
                 .withDefault(true)
-                .withLocation(new Location("", empty(), Optional.of("dataSource")))
+                .withLocation(new Location("", null, "dataSource"))
                 .build();
 
         final DefaultPublishedEventSource defaultPublishedEventSource = mock(DefaultPublishedEventSource.class);

--- a/event-sourcing/event-subscription-registry/src/test/java/uk/gov/justice/subscription/registry/EventSourceDefinitionRegistryProducerTest.java
+++ b/event-sourcing/event-subscription-registry/src/test/java/uk/gov/justice/subscription/registry/EventSourceDefinitionRegistryProducerTest.java
@@ -85,8 +85,8 @@ public class EventSourceDefinitionRegistryProducerTest {
         final URL url_1 = new URL("file:/test");
         final URL url_2 = new URL("file:/test");
 
-        final Location location1 = new Location("", empty(), of("dataSource"));
-        final Location location2 = new Location("", empty(), empty());
+        final Location location1 = new Location("", null, "dataSource");
+        final Location location2 = new Location("", null, null);
 
         final EventSourceDefinition eventSourceDefinition1 = eventSourceDefinition()
                 .withLocation(location1)
@@ -116,7 +116,7 @@ public class EventSourceDefinitionRegistryProducerTest {
         final EventSourceDefinition defaultEventSourceDefinition = new EventSourceDefinition(
                 "name",
                 true,
-                new Location("jms uri", of("rest uri"), of("data source name"))
+                new Location("jms uri", "rest uri", "data source name")
         );
 
         when(defaultEventSourceDefinitionFactory.createDefaultEventSource()).thenReturn(defaultEventSourceDefinition);

--- a/event-sourcing/event-subscription-registry/src/test/java/uk/gov/justice/subscription/registry/EventSourceDefinitionRegistryTest.java
+++ b/event-sourcing/event-subscription-registry/src/test/java/uk/gov/justice/subscription/registry/EventSourceDefinitionRegistryTest.java
@@ -46,7 +46,7 @@ public class EventSourceDefinitionRegistryTest {
     @Test
     public void shouldReturnDefaultEventSourceDefinition() {
 
-        final Location location = new Location("", empty(), Optional.of("dataSource"));
+        final Location location = new Location("", null, "dataSource");
 
         final EventSourceDefinition eventSourceDefinition1 = eventSourceDefinition()
                 .withLocation(location)
@@ -74,8 +74,8 @@ public class EventSourceDefinitionRegistryTest {
     @Test
     public void shouldThrowExceptionIfSecondDefaultEventSourceIsAdded() {
 
-        final Location location1 = new Location("", empty(), Optional.of("dataSource"));
-        final Location location2 = new Location("", empty(), Optional.of("dataSource"));
+        final Location location1 = new Location("", null, "dataSource");
+        final Location location2 = new Location("", null, "dataSource");
 
         final EventSourceDefinition eventSourceDefinition1 = eventSourceDefinition()
                 .withLocation(location1)
@@ -103,8 +103,8 @@ public class EventSourceDefinitionRegistryTest {
     @Test
     public void shouldThrowExceptionIfNoDataSourceDefinedForDefaultEventSource() {
 
-        final Location location1 = new Location("", empty(), empty());
-        final Location location2 = new Location("", empty(), empty());
+        final Location location1 = new Location("", null, null);
+        final Location location2 = new Location("", null, null);
 
         final EventSourceDefinition eventSourceDefinition1 = eventSourceDefinition()
                 .withLocation(location1)

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
     <properties>
         <cpp.repo.name>event-store</cpp.repo.name>
-        <framework.version>17.103.0</framework.version>
+        <framework.version>17.104.0-M1-SNAPSHOT</framework.version>
 
         <!-- junit 4 version needed for deltaspike tests. Should be moved to common bom -->
         <junit4.version>4.13.2</junit4.version>


### PR DESCRIPTION
Draft pull request to keep for reference:

Unfortunately upgrading the Jackson libraries we use conflicts with the version that wildfly 26 uses. We have 3 options.
- Don't upgrade and live with the security vulnerabilities
- Upgrade the Jackson modules in all our current wildfly deployments
- Upgrade Wildfly to a later version that uses a more secure version of Jackson

This pull request will not compile until these pull requests have been merged and released:
- https://github.com/hmcts/cp-maven-common-bom/pull/166
- https://github.com/hmcts/cp-framework-libraries/pull/160
- https://github.com/hmcts/cp-microservice-framework/pull/175
